### PR TITLE
Add post-packer Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ inner workings:
 ./patch_packer_config.py --help
 ```
 
+### Giving Other AWS Accounts Permission to Launch the Image ###
+
+After the AMI has been successfully created, you may want to allow other
+accounts in your AWS organization permission to launch it.  For this project,
+we want to allow all accounts whose names begin with "env" to launch the
+most-recently-created AMI.  To do that, follow these instructions:
+
+```console
+cd terraform-post-packer
+terraform init --upgrade=true
+terraform apply
+```
+
 ## Contributing ##
 
 We welcome contributions!  Please see [here](CONTRIBUTING.md) for

--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -1,0 +1,53 @@
+# Default AWS provider (EC2AMICreate role in the Images account)
+provider "aws" {
+  region  = "us-east-1"
+  profile = "cool-images-ec2amicreate"
+}
+
+# AWS provider for the Master account (OrganizationsReadOnly role)
+provider "aws" {
+  region  = "us-east-1"
+  profile = "cool-master-organizationsreadonly"
+  alias   = "master"
+}
+
+# Use aws_caller_identity with the default provider (Images account)
+# so we can provide the Images account ID below
+data "aws_caller_identity" "images" {
+}
+
+# The most-recent AMI created by cisagov/skeleton-packer-cool
+data "aws_ami" "example" {
+  filter {
+    name = "name"
+    values = [
+      "example-hvm-*-x86_64-ebs",
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners      = [data.aws_caller_identity.images.account_id]
+  most_recent = true
+}
+
+# Assign launch permissions to the AMI
+module "ami_launch_permission" {
+  source = "github.com/cisagov/ami-launch-permission-tf-module"
+
+  providers = {
+    aws        = aws
+    aws.master = aws.master
+  }
+
+  account_name_regex = "^env"
+  ami_id             = data.aws_ami.example.id
+}

--- a/terraform-post-packer/outputs.tf
+++ b/terraform-post-packer/outputs.tf
@@ -1,0 +1,4 @@
+output "accounts" {
+  value       = module.ami_launch_permission.accounts
+  description = "A map whose keys are the account names allowed to launch the AMI and whose values are the account IDs and the AMI ID."
+}

--- a/terraform-post-packer/terraform.tf
+++ b/terraform-post-packer/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "skeleton-packer-cool/terraform-post-packer.tfstate"
+  }
+}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds Terraform that can modify the most-recently-created AMI so that it can be launched from any AWS account (in our organization) whose name begins with "env".

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
All of our AMIs are created in the Images account, but they must be able to be launched from other accounts in our AWS organization.  This PR shows how that can be accomplished.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I applied this Terraform in the COOL and verified that the newest AMI from this repo was indeed assigned launch permissions for our two current "env*" AWS accounts.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
