### PR TITLE
Update the account lookup regex

### DIFF
--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -34,16 +34,12 @@ locals {
     x.name if x.id == data.aws_caller_identity.images.account_id
   ][0]
 
-  # Calculate what the environment account names should look like.  This
-  # assumes that the images account name is one word long, and any additional
-  # words are modifiers.
-  # Examples:
-  # Images -> "^env[[:digit:]]+$"
-  # Images Staging -> "^env[[:digit:]]+ Staging$"
-  # Images Alpha Testing -> "^env[[:digit:]]+ Alpha Testing$"
-  images_account_prefix = split(" ", local.images_account_name)[0]
-  images_account_suffix = trimprefix(local.images_account_name, local.images_account_prefix)
-  account_name_regex    = format("^env[[:digit:]]+%s$", local.images_account_suffix)
+  # Calculate what the names of the accounts that are allowed to use
+  # this AMI should look like.  In this case the only accounts that
+  # are allowed to use this AMI are the env* accounts of the same type
+  # (production, staging, etc.) as the Images account.
+  images_account_type = trim(split("(", local.images_account_name)[1], ")")
+  account_name_regex  = format("^env[[:digit:]]+ \\(%s\\)$", local.images_account_type)
 }
 
 # The most-recent AMI created by cisagov/skeleton-packer-cool


### PR DESCRIPTION
## 🗣 Description

This pull request modifies the regex used to compile a list of accounts that are allowed to use the AMI.

## 💭 Motivation and Context

We now append the account type (production, staging, etc.) to all of our accounts that use AMIs.  This simplifies the logic to construct the regex considerably, and renders the existing regex incorrect.

## 🧪 Testing

This is the same sort of regex I used successfully in cisagov/openvpn-packer#9.  See in particular the commit cisagov/openvpn-packer@0ed66f32714c5ebd674ea130cbd712f2853cf45f.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
